### PR TITLE
Bugfix and tests for rgbToHex, new utility rgbToString.

### DIFF
--- a/src/Mexitek/PHPColors/Color.php
+++ b/src/Mexitek/PHPColors/Color.php
@@ -179,9 +179,9 @@ class Color {
 
 
     /**
-     *  Given an RGB associative array returns the equivalent HEX string
+     * Given an RGB associative array returns the equivalent HEX string
      * @param array $rgb
-     * @return string RGB string
+     * @return string Hex string
      * @throws Exception "Bad RGB Array"
      */
     public static function rgbToHex( $rgb = array() ){
@@ -196,9 +196,33 @@ class Color {
         $hex[1] = str_pad(dechex($rgb['G']), 2, '0', STR_PAD_LEFT);
         $hex[2] = str_pad(dechex($rgb['B']), 2, '0', STR_PAD_LEFT);
 
+        // Make sure that 2 digits are allocated to each color.
+        $hex[0] = (strlen($hex[0]) == 1)? '0'.$hex[0] : $hex[0];
+        $hex[1] = (strlen($hex[1]) == 1)? '0'.$hex[1] : $hex[1];
+        $hex[2] = (strlen($hex[2]) == 1)? '0'.$hex[2] : $hex[2];
+
         return implode( '', $hex );
 
-  }
+    }
+
+    /**
+     * Given an RGB associative array, returns CSS string output.
+     * @param array $rgb
+     * @return string rgb(r,g,b) string
+     * @throws Exception "Bad RGB Array"
+     */
+    public static function rgbToString( $rgb = array() ){
+         // Make sure it's RGB
+        if(empty($rgb) || !isset($rgb["R"]) || !isset($rgb["G"]) || !isset($rgb["B"]) ) {
+            throw new Exception("Param was not an RGB array");
+        }
+
+        return 'rgb('.
+            $rgb['R'] . ', ' .
+            $rgb['G'] . ', ' .
+            $rgb['B'] . ')';
+    }
+
 
 
     /**

--- a/tests/colorConvert.phpt
+++ b/tests/colorConvert.phpt
@@ -1,0 +1,54 @@
+<?php
+
+require __DIR__ . '/bootstrap.php';
+
+use Mexitek\PHPColors\Color;
+use Tester\Assert;
+
+// Colors in RGB, for testing.
+$blue = [
+	'R' => 0,
+	'G' => 158,
+	'B' => 204,
+];
+$black = [
+	'R' => 0,
+	'G' => 0,
+	'B' => 0,
+];
+$white = [
+	'R' => 255,
+	'G' => 255,
+	'B' => 255,
+];
+
+// Test cases.
+$colorsToConvert = array(
+	'blue'  => [ // rgb(0, 158, 204): Thanks for the example, @strarsis.
+		'hex' => '009ecc',
+		'rgb' => $blue,
+	],
+	'black' => [
+		'hex' => '000000',
+		'rgb' => $black,
+	],
+	'white' => [
+		'hex' => 'ffffff',
+		'rgb' => $white,
+	],
+);
+
+
+foreach ($colorsToConvert as $color) {
+	$rgb = $color['rgb'];
+	$hex = $color['hex'];
+
+	$answer = Color::rgbToHex($rgb);
+	Assert::same(
+		$hex,
+		$answer,
+		'Incorrect hex result: "' . Color::rgbToString($rgb) .
+		'" should convert to "' . $hex .
+		'", but output was: "' . $answer . '".'
+	);
+}


### PR DESCRIPTION
This PR:
- Fixes https://github.com/mexitek/phpColors/issues/25 - a bug where rgbToHex has problems converting RGB value '0'.
- implements tests for `rgbToHex` in `colorConvert.phpt`.
- adds utility method `rgbToString`, to convert an RGB array to its CSS string representation.
- fixes whitespace, indentation, & commenting typos.