### PR TITLE
fix sanitizeHex regex check to check $color

### DIFF
--- a/src/Mexitek/PHPColors/Color.php
+++ b/src/Mexitek/PHPColors/Color.php
@@ -528,7 +528,7 @@ class Color
         $color = str_replace("#", "", $hex);
 
         // Validate hex string
-        if (!preg_match('/^[a-fA-F0-9]+$/', $hex)) {
+        if (!preg_match('/^[a-fA-F0-9]+$/', $color)) {
             throw new Exception("HEX color does not match format");
         }
 

--- a/tests/colorInput.phpt
+++ b/tests/colorInput.phpt
@@ -1,0 +1,19 @@
+<?php
+
+require __DIR__ . '/bootstrap.php';
+
+use Mexitek\PHPColors\Color;
+use Tester\Assert;
+
+// Test that a hex starting with '#' is supported as input
+$expected = array(
+    "#ffffff",
+    "#00ff00",
+    "#000000",
+    "#ff9a00",
+);
+
+foreach ($expected as $input) {
+    $color = new Color($input);
+    Assert::same((string) $color, $input, 'Incorrect color returned.');
+}


### PR DESCRIPTION
"HEX color does not match format" exception is thrown with any hex string starting with '#'.

This is because your variable storing the '#' stripped off is $color, not $hex.

So any usage of this lib passing in a hex string starting with '#' is broken at the moment, like `new Color('#ffffff')`