### PR TITLE
Enhance precision in HSL to HEX conversion

### DIFF
--- a/src/Mexitek/PHPColors/Color.php
+++ b/src/Mexitek/PHPColors/Color.php
@@ -143,15 +143,15 @@ class Color
 
             $var_1 = 2 * $L - $var_2;
 
-            $r = round(255 * self::hueToRgb($var_1, $var_2, $H + (1 / 3)));
-            $g = round(255 * self::hueToRgb($var_1, $var_2, $H));
-            $b = round(255 * self::hueToRgb($var_1, $var_2, $H - (1 / 3)));
+            $r = 255 * self::hueToRgb($var_1, $var_2, $H + (1 / 3));
+            $g = 255 * self::hueToRgb($var_1, $var_2, $H);
+            $b = 255 * self::hueToRgb($var_1, $var_2, $H - (1 / 3));
         }
 
         // Convert to hex
-        $r = dechex((int)$r);
-        $g = dechex((int)$g);
-        $b = dechex((int)$b);
+        $r = dechex(round($r));
+        $g = dechex(round($g));
+        $b = dechex(round($b));
 
         // Make sure we get 2 digits for decimals
         $r = (strlen("" . $r) === 1) ? "0" . $r : $r;

--- a/tests/colorConvertHslToHex.phpt
+++ b/tests/colorConvertHslToHex.phpt
@@ -47,7 +47,7 @@ $colorsToConvert = array(
         'hsl' => $black,
     ],
     'grey' => [
-        'hex' => 'a5a5a5',
+        'hex' => 'a6a6a6',
         'hsl' => $grey,
     ],
     'white' => [


### PR DESCRIPTION
Conversion from HSL to HEX of a grey color produces unexpected result in some cases, due to a rude `int` casting.

For instance, converting a `hsl(0, 0, 65%)` will produces `rgb(165.75, 165.75, 165.75)`. Casting these values to an int will just strip their floating part (i.e 165.75 -> 165), while a round operation would result in a more appropriate result.
