### PR TITLE
Exclude dev files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.github/ export-ignore
+/demo/ export-ignore
+/tests/ export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.phpcs.xml export-ignore


### PR DESCRIPTION
For the time being, when fetching the dist package from composer, all repository files are included.
Using `export-ignore` git attribute would permit to make the dist package ligther (see https://php.watch/articles/composer-gitattributes#export-ignore).

Ignore files weight: 42.0kB
Remaining files weight: 40.3kB